### PR TITLE
Add the remainder of Reputation to the proapi client library

### DIFF
--- a/src/main/java/com/whitepages/proapi/api/client/responsedecoders/jsonjacksondecoder/PhoneReputationAnnotations.java
+++ b/src/main/java/com/whitepages/proapi/api/client/responsedecoders/jsonjacksondecoder/PhoneReputationAnnotations.java
@@ -1,5 +1,6 @@
 package com.whitepages.proapi.api.client.responsedecoders.jsonjacksondecoder;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -7,6 +8,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 abstract class PhoneReputationAnnotations {
 
-    PhoneReputationAnnotations(@JsonProperty("spam_score") int spamScore){};
+    @JsonCreator
+    PhoneReputationAnnotations(@JsonProperty("spam_score") int spamScore,
+			       @JsonProperty("spam_index") int spamIndex,
+			       @JsonProperty("volume_score") int volumeScore,
+			       @JsonProperty("report_count") int reportCount){};
 
 }

--- a/src/main/java/com/whitepages/proapi/data/entity/Phone.java
+++ b/src/main/java/com/whitepages/proapi/data/entity/Phone.java
@@ -76,15 +76,36 @@ public interface Phone extends Entity {
 
     public static class Reputation {
 
-        public Reputation(int spamScore) {
+        public Reputation(int spamScore,
+			  int spamIndex,
+			  int volumeScore,
+			  int reportCount) {
             this.spamScore = spamScore;
+	    this.spamIndex = spamIndex;
+	    this.volumeScore = volumeScore;
+	    this.reportCount = reportCount;
         }
 
         public Integer getSpamScore() {
             return spamScore;
         }
 
-        private Integer spamScore;
+	public Integer getSpamIndex() {
+            return spamIndex;
+        }
+
+	public Integer getVolumeScore() {
+            return volumeScore;
+        }
+
+	public Integer getReportCount() {
+            return reportCount;
+        }
+
+	private Integer spamScore;
+	private Integer spamIndex;
+	private Integer volumeScore;
+	private Integer reportCount;
 
     }
 }


### PR DESCRIPTION
The Reputation of a given phone number was not being fully populated from the JSON response - in particular, the spam_index, volume_score, and report_count fields were being ignored by the Java
client library.  This PR fixes it so that all of the reputation fields are read from the JSON response.  No new test breakage from these changes.